### PR TITLE
luci: Fix native IPv6 proxy with V2ray

### DIFF
--- a/luci-app-passwall/Makefile
+++ b/luci-app-passwall/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=luci-app-passwall
-PKG_VERSION:=4.36
+PKG_VERSION:=4.37
 PKG_RELEASE:=1
 #20210928
 

--- a/luci-app-passwall/luasrc/model/cbi/passwall/api/gen_v2ray.lua
+++ b/luci-app-passwall/luasrc/model/cbi/passwall/api/gen_v2ray.lua
@@ -4,6 +4,7 @@ local api = require "luci.model.cbi.passwall.api.api"
 local var = api.get_args(arg)
 local node_section = var["-node"]
 local proto = var["-proto"]
+local proxy_way = var["-proxy_way"]
 local redir_port = var["-redir_port"]
 local local_socks_address = var["-local_socks_address"] or "0.0.0.0"
 local local_socks_port = var["-local_socks_port"]
@@ -261,6 +262,7 @@ if node_section then
             port = tonumber(redir_port),
             protocol = "dokodemo-door",
             settings = {network = proto, followRedirect = true},
+            streamSettings = {sockopt = {tproxy = proxy_way}},
             sniffing = {enabled = true, destOverride = {"http", "tls"}}
         })
     end

--- a/luci-app-passwall/luasrc/model/cbi/passwall/client/other.lua
+++ b/luci-app-passwall/luasrc/model/cbi/passwall/client/other.lua
@@ -91,6 +91,22 @@ if os.execute("lsmod | grep -i REDIRECT >/dev/null") == 0 and os.execute("lsmod 
     o.default = "redirect"
     o:value("redirect", "REDIRECT")
     o:value("tproxy", "TPROXY")
+    o:depends("ipv6_tproxy", false)
+    function o.formvalue(self, section)
+        local ipv6_tproxy = ListValue.formvalue(o_ipv6_tproxy, section)
+        if ipv6_tproxy == "1" then
+            return "tproxy"
+        end
+        return ListValue.formvalue(self, section)
+    end
+
+    ---- IPv6 TProxy
+    o_ipv6_tproxy = s:option(Flag, "ipv6_tproxy", translate("IPv6 TProxy"),
+                 "<font color='red'>" .. translate(
+                     "Experimental feature. Make sure that your node supports IPv6.") ..
+                     "</font>")
+    o_ipv6_tproxy.default = 0
+    o_ipv6_tproxy.rmempty = false
 end
 
 --[[
@@ -117,14 +133,6 @@ o.rmempty = true
 s = m:section(TypedSection, "global_other", translate("Other Settings"))
 s.anonymous = true
 s.addremove = false
-
----- IPv6 TProxy
-o = s:option(Flag, "ipv6_tproxy", translate("IPv6 TProxy"),
-             "<font color='red'>" .. translate(
-                 "Experimental feature.Make sure that your node supports IPv6.") ..
-                 "</font>")
-o.default = 0
-o.rmempty = false
 
 o = s:option(MultiValue, "status", translate("Status info"))
 o:value("big_icon", translate("Big icon")) -- 大图标

--- a/luci-app-passwall/po/zh-cn/passwall.po
+++ b/luci-app-passwall/po/zh-cn/passwall.po
@@ -1168,7 +1168,7 @@ msgstr "目前最多只能设置%s个节点，用于给访问控制使用。"
 msgid "IPv6 TProxy"
 msgstr "IPv6透明代理(TProxy)"
 
-msgid "Experimental feature.Make sure that your node supports IPv6."
+msgid "Experimental feature. Make sure that your node supports IPv6."
 msgstr "实验特性，请确保你的节点支持IPv6"
 
 msgid "Status info"

--- a/luci-app-passwall/root/usr/share/passwall/0_default_config
+++ b/luci-app-passwall/root/usr/share/passwall/0_default_config
@@ -33,11 +33,11 @@ config global_forwarding
 	option udp_redir_ports '1:65535'
 	option accept_icmp '0'
 	option tcp_proxy_way 'redirect'
-	
+	option ipv6_tproxy '0'
+
 config global_other
 	option status 'big_icon show_check_port show_ip111'
 	option nodes_ping 'auto_ping tcping'
-	option ipv6_tproxy '0'
 
 config global_rules
 	option auto_update '0'
@@ -79,7 +79,7 @@ config auto_switch
 	option connect_timeout '3'
 	option retry_num '3'
 	option shunt_logic '1'
-	
+
 config nodes '696cd32c1d5149ee95fd1b3accbad6df'
 	option remarks '分流总节点'
 	option type 'Xray'
@@ -93,7 +93,7 @@ config nodes '696cd32c1d5149ee95fd1b3accbad6df'
 	option China 'nil'
 	option default_node 'nil'
 	option domainStrategy 'IPIfNonMatch'
-	
+
 config shunt_rules 'AD'
 	option remarks 'AD'
 	option domain_list 'geosite:category-ads'
@@ -101,7 +101,7 @@ config shunt_rules 'AD'
 config shunt_rules 'BT'
 	option remarks 'BT'
 	option protocol 'bittorrent'
-	
+
 config shunt_rules 'Telegram'
 	option remarks 'Telegram'
 	option ip_list '149.154.160.0/20


### PR DESCRIPTION
* V2ray doesn't support REDIRECT mode with IPv6 so we need to set
   sockopt.tproxy as tproxy when IPv6 is enabled. Arguably we could use
   REDIRECT for IPv4 but that would require an additional port.
 * V2ray doesn't support IPv6 UDP, adding corresponding ip6tables rules
   results in a deadlock of failures and break IPv4 UDP.
 * Now that IPv4/6 TCP and IPv4 UDP are working with both native IPv6
   and NAT6.

Reference: https://github.com/v2ray/v2ray-core/issues/1309
Fixes #1394